### PR TITLE
Address remarks on documentation for minimal_scheduling 

### DIFF
--- a/minimal_scheduling/README.md
+++ b/minimal_scheduling/README.md
@@ -134,6 +134,9 @@ $ ps -C minimal_schedul -L -o tid,comm,rtprio,cls,psr
    6803 minimal_sched_f     80  FF   7
 ```
 
+This is similar to configuring the process real-time atrributes using the Linux [`chrt`](https://www.man7.org/linux/man-pages/man1/chrt.1.html)
+tool.
+
 <script id="asciicast-WtoeazuOds4CCpBDA0Mfkg8Ly" src="https://asciinema.org/a/WtoeazuOds4CCpBDA0Mfkg8Ly.js" async></script>
 
 ### minimal_scheduling_spin_thread


### PR DESCRIPTION
This PR addresses the comments from #6 

- [x] Add a comment about setting the process attributes using chrt
- [ ] Consider merging minimal_scheduling_main_thread and minimal_scheduling_middleware_threads in a single executable
- [ ] Consider removing  minimal_scheduling_spin_thread

Closes #6 